### PR TITLE
Remove all the ->gen_packet stuff.

### DIFF
--- a/include/net.h
+++ b/include/net.h
@@ -38,7 +38,6 @@ struct netproto {
 	void (*socket_setup)(int fd);
 	void (*setsockopt)(struct sockopt *so, struct socket_triplet *triplet);
 	void (*gen_sockaddr)(struct sockaddr **addr, socklen_t *addrlen);
-	void (*gen_packet)(struct socket_triplet *st, void **ptr, size_t *len);
 	unsigned int nr_triplets;
 	unsigned int nr_privileged_triplets;
 };


### PR DESCRIPTION
This was never implemented, and is aparently broken on 32bit (https://github.com/kernelslacker/trinity/pull/52)