### PR TITLE
ioctl/drm: fix drm_nouveau compile issue (#53)

### DIFF
--- a/configure
+++ b/configure
@@ -313,6 +313,60 @@ else
 fi
 
 #############################################################################################
+# Does header define struct drm_nouveau_notifierobj_alloc
+#
+echo -n "[*] Checking if struct drm_nouveau_notifierobj_alloc is defined"
+rm -f "$TMP" || exit 1
+
+cat >"$TMP.c" << EOF
+#define _GNU_SOURCE
+#include <drm/nouveau_drm.h>
+#include <stdio.h>
+
+void main()
+{
+	struct drm_nouveau_notifierobj_alloc dnna = {0,0,0,0};
+	dnna.size = 64;
+	printf("size=%d\n", dnna.size);
+}
+EOF
+
+${CC} ${CFLAGS} "$TMP.c" -o "$TMP" &>"$TMP.log"
+if [ ! -x "$TMP" ]; then
+	echo $RED "[NO]" $COL_RESET
+else
+	echo $GREEN "[YES]" $COL_RESET
+	echo "#define USE_DEFAULT_STRUCT_DRM_NOUVEAU_NOTIFIEROBJ_ALLOC 1" >> $CONFIGH
+fi
+
+#############################################################################################
+# Does header define struct drm_nouveau_notifierobj_alloc
+#
+echo -n "[*] Checking if struct drm_nouveau_gpuobj_free is defined"
+rm -f "$TMP" || exit 1
+
+cat >"$TMP.c" << EOF
+#define _GNU_SOURCE
+#include <drm/nouveau_drm.h>
+#include <stdio.h>
+
+void main()
+{
+	struct drm_nouveau_gpuobj_free dngf = {0,0};
+	dngf.channel = 64;
+	printf("channel=%d\n", dngf.channel);
+}
+EOF
+
+${CC} ${CFLAGS} "$TMP.c" -o "$TMP" &>"$TMP.log"
+if [ ! -x "$TMP" ]; then
+	echo $RED "[NO]" $COL_RESET
+else
+	echo $GREEN "[YES]" $COL_RESET
+	echo "#define USE_DEFAULT_STRUCT_DRM_NOUVEAU_GPUOBJ_FREE 1" >> $CONFIGH
+fi
+
+#############################################################################################
 
 check_header linux/caif/caif_socket.h USE_CAIF
 check_header linux/fsmap.h USE_FSMAP

--- a/ioctls/drm.c
+++ b/ioctls/drm.c
@@ -129,21 +129,25 @@ struct drm_nouveau_grobj_alloc {
 #define DRM_IOCTL_NOUVEAU_GROBJ_ALLOC        DRM_IOW (DRM_COMMAND_BASE + DRM_NOUVEAU_GROBJ_ALLOC, struct drm_nouveau_grobj_alloc)
 #endif
 
-#ifndef DRM_IOCTL_NOUVEAU_NOTIFIEROBJ_ALLOC
+#ifndef USE_DEFAULT_STRUCT_DRM_NOUVEAU_NOTIFIEROBJ_ALLOC
 struct drm_nouveau_notifierobj_alloc {
 	uint32_t channel;
 	uint32_t handle;
 	uint32_t size;
 	uint32_t offset;
 };
+#endif
+#ifndef DRM_IOCTL_NOUVEAU_NOTIFIEROBJ_ALLOC
 #define DRM_IOCTL_NOUVEAU_NOTIFIEROBJ_ALLOC  DRM_IOWR(DRM_COMMAND_BASE + DRM_NOUVEAU_NOTIFIEROBJ_ALLOC, struct drm_nouveau_notifierobj_alloc)
 #endif
 
-#ifndef DRM_IOCTL_NOUVEAU_GPUOBJ_FREE
+#ifndef USE_DEFAULT_STRUCT_DRM_NOUVEAU_GPUOBJ_FREE
 struct drm_nouveau_gpuobj_free {
 	int      channel;
 	uint32_t handle;
 };
+#endif
+#ifndef DRM_IOCTL_NOUVEAU_GPUOBJ_FREE
 #define DRM_IOCTL_NOUVEAU_GPUOBJ_FREE        DRM_IOW (DRM_COMMAND_BASE + DRM_NOUVEAU_GPUOBJ_FREE, struct drm_nouveau_gpuobj_free)
 #endif
 


### PR DESCRIPTION
since 460be1d527a8 ("drm/nouveau: move more missing UAPI bits") in v6.10-rc1, the two structs are moved to the uapi in include/drm/drm_nouveau.h (drm_nouveau_notifierobj_alloc and drm_nouveau_gpuobj_free), so the definition of the macros and the structs are not in the same place any more, so can't use the macros to determine if the two structs are defined. So change to compile in configure to determine that.